### PR TITLE
Fixed figure position (?) 

### DIFF
--- a/chapters/introduction.tex
+++ b/chapters/introduction.tex
@@ -37,13 +37,13 @@ Chapter~\ref{chap:introduction} is what you're currently reading, and its name i
 Section~\ref{sec:code} is about pseudo-code.
 The next Chapter (\nameref{chap:rw}), is on page~\pageref{chap:rw}.
 
-
+\pagebreak
 %%%
 %
 \section{Figures}
 \label{sec:figures}
 
-\begin{figure}
+\begin{figure}[!ht]
   \centering
   \includegraphics[width=0.8\linewidth]{figs/sometriangles.png}
   \caption{One nice figure}
@@ -51,7 +51,7 @@ The next Chapter (\nameref{chap:rw}), is on page~\pageref{chap:rw}.
 \end{figure}
 
 As shown in Figure~\ref{fig:sidebyside},
-\begin{figure}
+\begin{figure}[!ht]
   \centering
   \begin{subfigure}[b]{0.45\linewidth}
     \centering
@@ -76,7 +76,7 @@ You can also refer to a subfigure: see Figure~\ref{fig:sidebyside:2}.
 If you use Adobe Illustrator or Ipe you can make your figures vectorial and save them in PDF\@.
 
 You include a PDF the same way as you do for a PNG, see Figure~\ref{fig:pdffig},
-\begin{figure}
+\begin{figure}[!ht]
   \centering
   \begin{subfigure}[b]{0.28\linewidth}
     \centering


### PR DESCRIPTION
The figures jumped to the bottom of the section. 
By using pagebreak and [!ht] they were fixed. 
There is probably a better way, but the figures are in place now. 
